### PR TITLE
Close cursor when filtering ignored deck cards

### DIFF
--- a/server/util/mtgCardSearch/searchFunctions.go
+++ b/server/util/mtgCardSearch/searchFunctions.go
@@ -34,15 +34,16 @@ func FilterCards(cards []*model.MtgCard, filter model.MtgFilterSearchInput, sort
 	if filter.DeckID != nil && filter.HideIgnored {
 		ctx := context.Background()
 		aq := arango.NewQuery( /* aql */ `
-			FOR card, edge IN 1..1 OUTBOUND CONCAT("MTG_Decks/", @deckID) MTG_Deck_Ignore_Card
-			RETURN card._key
-		`)
+                        FOR card, edge IN 1..1 OUTBOUND CONCAT("MTG_Decks/", @deckID) MTG_Deck_Ignore_Card
+                        RETURN card._key
+                `)
 		aq.AddBindVar("deckID", *filter.DeckID)
 		cursor, err := arango.DB.Query(ctx, aq.Query, aq.BindVars)
 		if err != nil {
 			log.Error().Err(err).Msg("Error querying database")
 			return []*model.MtgCard{}
 		}
+		defer cursor.Close()
 		for cursor.HasMore() {
 			var ignoredCard string
 			_, err := cursor.ReadDocument(ctx, &ignoredCard)


### PR DESCRIPTION
## Summary
- close database cursor when loading ignored card IDs to prevent resource leaks

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b8dc7ef7708320a44f900638f50fdd